### PR TITLE
Remove pull-secret for db connection and simple cluster samples

### DIFF
--- a/.github/workflows/updateCafeAppAks.yml
+++ b/.github/workflows/updateCafeAppAks.yml
@@ -9,9 +9,6 @@ on:
       appNamespace:
         description: "Open Liberty App namespace"
         required: true
-      appNamespacePullSecret:
-        description: "Open Liberty App namespace pull secret"
-        required: true
       clusterName: 
         description: "AKS cluster name"
         required: true
@@ -82,7 +79,6 @@ jobs:
                 echo "DB_USER"=${{ env.dbAdminUser }} >> $GITHUB_ENV
                 echo "DB_PASSWORD"=${{ env.dbPassword }} >> $GITHUB_ENV
                 echo "NAMESPACE"=${{ github.event.inputs.appNamespace }} >> $GITHUB_ENV
-                echo "PULL_SECRET"=${{ github.event.inputs.appNamespacePullSecret }} >> $GITHUB_ENV
             - name: Build the app
               run: |
                 echo "build the Cafe web app"
@@ -98,7 +94,6 @@ jobs:
                 export DB_USER=$DB_USER
                 export DB_PASSWORD=$DB_PASSWORD
                 export NAMESPACE=$NAMESPACE
-                export PULL_SECRET=$PULL_SECRET
 
                 mvn clean install
             - name: Archive server.xml

--- a/javaee-app-db-using-actions/mssql/pom.xml
+++ b/javaee-app-db-using-actions/mssql/pom.xml
@@ -37,7 +37,6 @@
     <param.db.name>${env.DB_NAME}</param.db.name>
     <param.db.user>${env.DB_USER}</param.db.user>
     <param.db.password>${env.DB_PASSWORD}</param.db.password>
-    <param.pull.secret.name>${env.PULL_SECRET}</param.pull.secret.name>
     <param.namespace>${env.NAMESPACE}</param.namespace>
     <param.replicas>3</param.replicas>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/javaee-app-db-using-actions/mssql/src/main/aks/openlibertyapplication.yaml
+++ b/javaee-app-db-using-actions/mssql/src/main/aks/openlibertyapplication.yaml
@@ -7,7 +7,6 @@ spec:
   replicas: ${param.replicas}
   applicationImage: ${param.login.server}/${project.artifactId}:${project.version}
   pullPolicy: Always
-  pullSecret: ${param.pull.secret.name}
   service:
     type: LoadBalancer
     targetPort: 9080

--- a/javaee-app-db-using-actions/postgres/pom.xml
+++ b/javaee-app-db-using-actions/postgres/pom.xml
@@ -38,7 +38,6 @@
     <param.db.name>${env.DB_TYPE}</param.db.name>
     <param.db.user>${env.DB_USER}</param.db.user>
     <param.db.password>${env.DB_PASSWORD}</param.db.password>
-    <param.pull.secret.name>${env.PULL_SECRET}</param.pull.secret.name>
     <param.namespace>${env.NAMESPACE}</param.namespace>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/javaee-app-db-using-actions/postgres/src/main/aks/openlibertyapplication.yaml
+++ b/javaee-app-db-using-actions/postgres/src/main/aks/openlibertyapplication.yaml
@@ -7,7 +7,6 @@ spec:
   replicas: ${param.replicas}
   applicationImage: ${param.login.server}/${project.artifactId}:${project.version}
   pullPolicy: Always
-  pullSecret: ${param.pull.secret.name}
   service:
     type: LoadBalancer
     port: 9080

--- a/javaee-app-simple-cluster/pom.xml
+++ b/javaee-app-simple-cluster/pom.xml
@@ -22,7 +22,6 @@
     <param.login.server>${env.LOGIN_SERVER}</param.login.server>
     <param.registry.name>${env.REGISTRY_NAME}</param.registry.name>
     <param.password>${env.PASSWORD}</param.password>
-    <param.pull.secret.name>acr-secret</param.pull.secret.name>
     <param.user.name>${env.USER_NAME}</param.user.name>
     <param.replicas>3</param.replicas>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -130,31 +129,7 @@
             <version>1.6.0</version>
             <executions>
               <execution>
-                <id>00-delete-secret</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>exec</goal>
-                </goals>
-                <configuration>
-                  <workingDirectory>${project.build.directory}</workingDirectory>
-                  <executable>kubectl</executable>
-                  <commandlineArgs>delete secret docker-registry ${param.pull.secret.name} --ignore-not-found</commandlineArgs>
-                </configuration>
-              </execution>
-              <execution>
-                <id>01-create-secret</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>exec</goal>
-                </goals>
-                <configuration>
-                  <workingDirectory>${project.build.directory}</workingDirectory>
-                  <executable>kubectl</executable>
-                  <commandlineArgs>create secret docker-registry ${param.pull.secret.name} --docker-server=${param.login.server} --docker-username=${param.user.name} --docker-password=${param.password}</commandlineArgs>
-                </configuration>
-              </execution>
-              <execution>
-                <id>02-acr-build</id>
+                <id>01-acr-build</id>
                 <phase>verify</phase>
                 <goals>
                   <goal>exec</goal>
@@ -166,7 +141,7 @@
                 </configuration>
               </execution>
               <execution>
-                <id>03-kubectl-apply</id>
+                <id>02-kubectl-apply</id>
                 <phase>verify</phase>
                 <goals>
                   <goal>exec</goal>

--- a/javaee-app-simple-cluster/src/main/aks/openlibertyapplication.yaml
+++ b/javaee-app-simple-cluster/src/main/aks/openlibertyapplication.yaml
@@ -6,7 +6,6 @@ spec:
   replicas: ${param.replicas}
   applicationImage: ${param.login.server}/${project.artifactId}:${project.version}
   pullPolicy: Always
-  pullSecret: ${param.pull.secret.name}
   service:
     type: LoadBalancer
     targetPort: 9080


### PR DESCRIPTION
Need to sync with doc change: https://github.com/MicrosoftDocs/azure-docs-pr/pull/186432

**Changes**
* Remove pull-secret related login in `/javaee-app-db-using-actions/mssql/` and `javaee-app-db-using-actions/postgres`
* Remove pull-secret related login in `javaee-app-simple-cluster/`
* Update `updateCafeAppAks.yml` to adopt these changes

**Tests**
* Following `howto-deploy-java-liberty-app-with-postgresql` and using [jianguo's test offer](https://ms.portal.azure.com/#create/microsoft_javaeeonazure_test.20191212-arm-rhel-was-nd-v9-cluster-previewazure-liberty-aks) to test `javaee-app-db-using-actions/postgres`
* Following `howto-deploy-java-liberty-app` to test `javaee-app-simple-cluster/`
* No need to test the `javaee-app-db-using-actions/mssql` since it shares the same doc with `javaee-app-simple-cluster/`
* No need to test the pipeline

Signed-off-by: Zheng Chang <zhengchang@microsoft.com>