### PR TITLE
Required changes after upgrading postgres jdbc driver to 42.3.3

### DIFF
--- a/javaee-app-db-using-actions/postgres/src/main/docker/Dockerfile
+++ b/javaee-app-db-using-actions/postgres/src/main/docker/Dockerfile
@@ -4,7 +4,7 @@ FROM openliberty/open-liberty:kernel-java8-openj9-ubi
 # Add config, app and jdbc driver
 COPY --chown=1001:0 liberty/wlp/usr/servers/defaultServer/server.xml /config/server.xml
 COPY --chown=1001:0 ${project.artifactId}.war /config/apps/
-COPY --chown=1001:0 liberty/wlp/usr/shared/resources/postgresql-42.2.4.jar /opt/ol/wlp/usr/shared/resources/
+COPY --chown=1001:0 liberty/wlp/usr/shared/resources/postgresql-42.3.3.jar /opt/ol/wlp/usr/shared/resources/
 
 # This script will add the requested XML snippets, grow image to be fit-for-purpose and apply interim fixes
 RUN configure.sh

--- a/javaee-app-db-using-actions/postgres/src/main/docker/Dockerfile-local
+++ b/javaee-app-db-using-actions/postgres/src/main/docker/Dockerfile-local
@@ -5,7 +5,7 @@ FROM openliberty/open-liberty:kernel-java8-openj9-ubi
 COPY --chown=1001:0 liberty/wlp/usr/servers/defaultServer/server.xml /config/server.xml
 COPY --chown=1001:0 liberty/wlp/usr/servers/defaultServer/bootstrap.properties /config/bootstrap.properties
 COPY --chown=1001:0 ${project.artifactId}.war /config/apps/
-COPY --chown=1001:0 liberty/wlp/usr/shared/resources/postgresql-42.2.4.jar /opt/ol/wlp/usr/shared/resources/
+COPY --chown=1001:0 liberty/wlp/usr/shared/resources/postgresql-42.3.3.jar /opt/ol/wlp/usr/shared/resources/
 
 # This script will add the requested XML snippets, grow image to be fit-for-purpose and apply interim fixes
 RUN configure.sh

--- a/javaee-app-db-using-actions/postgres/src/main/docker/Dockerfile-wlp
+++ b/javaee-app-db-using-actions/postgres/src/main/docker/Dockerfile-wlp
@@ -4,7 +4,7 @@ FROM ibmcom/websphere-liberty:full-java8-openj9-ubi
 # Add config, app and jdbc driver
 COPY --chown=1001:0 liberty/wlp/usr/servers/defaultServer/server.xml /config/server.xml
 COPY --chown=1001:0 ${project.artifactId}.war /config/apps/
-COPY --chown=1001:0 liberty/wlp/usr/shared/resources/postgresql-42.2.4.jar /opt/ibm/wlp/usr/shared/resources/
+COPY --chown=1001:0 liberty/wlp/usr/shared/resources/postgresql-42.3.3.jar /opt/ibm/wlp/usr/shared/resources/
 
 # This script will add the requested XML snippets, grow image to be fit-for-purpose and apply interim fixes
 RUN configure.sh

--- a/javaee-app-db-using-actions/postgres/src/main/docker/Dockerfile-wlp-local
+++ b/javaee-app-db-using-actions/postgres/src/main/docker/Dockerfile-wlp-local
@@ -5,7 +5,7 @@ FROM ibmcom/websphere-liberty:full-java8-openj9-ubi
 COPY --chown=1001:0 liberty/wlp/usr/servers/defaultServer/server.xml /config/server.xml
 COPY --chown=1001:0 liberty/wlp/usr/servers/defaultServer/bootstrap.properties /config/bootstrap.properties
 COPY --chown=1001:0 ${project.artifactId}.war /config/apps/
-COPY --chown=1001:0 liberty/wlp/usr/shared/resources/postgresql-42.2.4.jar /opt/ibm/wlp/usr/shared/resources/
+COPY --chown=1001:0 liberty/wlp/usr/shared/resources/postgresql-42.3.3.jar /opt/ibm/wlp/usr/shared/resources/
 
 # This script will add the requested XML snippets, grow image to be fit-for-purpose and apply interim fixes
 RUN configure.sh

--- a/javaee-app-db-using-actions/postgres/src/main/liberty/config/server.xml
+++ b/javaee-app-db-using-actions/postgres/src/main/liberty/config/server.xml
@@ -32,7 +32,7 @@
             password="${db.password}"
             ssl="${db.ssl}" />
     </dataSource>
-    <variable name="db.ssl" defaultValue="true"/>
+    <variable name="db.ssl" defaultValue="false"/>
 
     <library id="driver-library">
         <fileset dir="${shared.resource.dir}" includes="*.jar" />


### PR DESCRIPTION
## Description

This PR targets to fix the new issues after upgrading postgres jdbc driver to 42.3.3 which was introduced by #18. 

## Change summary:
* Change to postgresql-42.3.3.jar in Dockerfile 
* Workaround ssl certificate restriction after upgrading postgres jdbc driver to 42.3.3 (see https://github.com/cloudcaptainsh/cloudcaptain/issues/234 for more info):
   ```
   Internal Exception: java.sql.SQLException: Could not open SSL root certificate file //.postgresql/root.crt
   ```

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>