### PR TITLE
Add soReuseAddr="true" to server.xml

### DIFF
--- a/java-app-jcache/src/main/liberty/config/server.xml
+++ b/java-app-jcache/src/main/liberty/config/server.xml
@@ -13,6 +13,8 @@
     <!-- Define http & https endpoints -->
     <httpEndpoint id="defaultHttpEndpoint" host="*"
         httpPort="9080" httpsPort="9443" />
+    <tcpOptions soReuseAddr="true" />
+    
 
     <library id="jCacheVendorLib">
       <fileset dir="${shared.resource.dir}" includes="*"/>

--- a/java-app/src/main/liberty/config/server.xml
+++ b/java-app/src/main/liberty/config/server.xml
@@ -13,6 +13,7 @@
     <!-- Define http & https endpoints -->
     <httpEndpoint id="defaultHttpEndpoint" host="*"
         httpPort="9080" httpsPort="9443" />
+    <tcpOptions soReuseAddr="true" />
 
     <!-- Automatically expand WAR files and EAR files -->
     <applicationManager autoExpand="true" />


### PR DESCRIPTION
Fixed error message on run command when running in WSL on Windows- 
_CWWKO0221E: TCP Channel defaultHttpEndpoint initialization did not succeed.  The socket bind did not succeed for host * and port 9080.  The port might already be in use.  Exception Message: Address already in use_
Issue: Port9080 is not immediately released from use between runs.  I suspect this is not unique to WSL on windows.  

Fix: add <tcpOptions soReuseAddr="true" /> to server.xml in 2 places