### PR TITLE
Update version

### DIFF
--- a/java-app/src/main/aks/openlibertyapplication-agic.yaml
+++ b/java-app/src/main/aks/openlibertyapplication-agic.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps.openliberty.io/v1beta2
+apiVersion: apps.openliberty.io/v1
 kind: OpenLibertyApplication
 metadata:
   name: javaee-cafe-cluster-agic

--- a/java-app/src/main/aks/openlibertyapplication.yaml
+++ b/java-app/src/main/aks/openlibertyapplication.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps.openliberty.io/v1beta2
+apiVersion: apps.openliberty.io/v1
 kind: OpenLibertyApplication
 metadata:
   name: javaee-cafe-cluster

--- a/java-app/src/main/docker/Dockerfile
+++ b/java-app/src/main/docker/Dockerfile
@@ -1,9 +1,15 @@
 # DisableDockerDetector "liberty-maven-plugin does not support docker buildx-build. See https://github.com/OpenLiberty/ci.maven/issues/1589"
 # open liberty base image
-FROM openliberty/open-liberty:kernel-java8-openj9-ubi
+FROM icr.io/appcafe/open-liberty:23.0.0.3-kernel-slim-java17-openj9-ubi
 
-# Add config, app and jdbc driver
+# Add config
 COPY --chown=1001:0 liberty/wlp/usr/servers/defaultServer/server.xml /config/server.xml
+
+# This script will add the requested XML snippets to enable Liberty features and grow image to be fit-for-purpose using featureUtility.
+# Only available in 'kernel-slim'. The 'full' tag already includes all features for convenience.
+RUN features.sh
+
+# Add app and jdbc driver
 COPY --chown=1001:0 javaee-cafe.war /config/apps/
 COPY --chown=1001:0 liberty/wlp/usr/shared/resources/mssql-jdbc-8.2.2.jre8.jar /opt/ol/wlp/usr/shared/resources/
 

--- a/java-app/src/main/docker/Dockerfile-wlp
+++ b/java-app/src/main/docker/Dockerfile-wlp
@@ -1,9 +1,15 @@
 # DisableDockerDetector "liberty-maven-plugin does not support docker buildx-build. See https://github.com/OpenLiberty/ci.maven/issues/1589"
 # WebSphere Liberty base image
-FROM ibmcom/websphere-liberty:full-java8-openj9-ubi
+FROM icr.io/appcafe/websphere-liberty:23.0.0.3-kernel-java17-openj9-ubi
 
-# Add config, app and jdbc driver
+# Add config
 COPY --chown=1001:0 liberty/wlp/usr/servers/defaultServer/server.xml /config/server.xml
+
+# This script will add the requested XML snippets to enable Liberty features and grow image to be fit-for-purpose using featureUtility.
+# Only available in 'kernel-slim'. The 'full' tag already includes all features for convenience.
+RUN features.sh
+
+# Add app and jdbc driver
 COPY --chown=1001:0 javaee-cafe.war /config/apps/
 COPY --chown=1001:0 liberty/wlp/usr/shared/resources/mssql-jdbc-8.2.2.jre8.jar /opt/ibm/wlp/usr/shared/resources/
 


### PR DESCRIPTION
The PR is to:
* use open liberty server version `23.0.0.3` and java17 in base image, which aligns with #33
* use ola `v1` which is supported by olo v1.2.0+, see [Operator upgrade from 0.8.x](https://github.com/OpenLiberty/open-liberty-operator/blob/main/doc/user-guide-v1.adoc#operator-upgrade-from-08x)

Tested with running the app locally, building and running the docker image locally, and deploying and running the app on an AKS.